### PR TITLE
Shorten summary

### DIFF
--- a/io.github.wartybix.Constrict.json
+++ b/io.github.wartybix.Constrict.json
@@ -68,8 +68,8 @@
             "sources" : [
                 {
                     "type" : "archive",
-                    "url" : "https://github.com/Wartybix/Constrict/archive/refs/tags/25.7.tar.gz",
-                    "sha256" : "3edf9c8bd3c271e231ba88e0428c51a83f73b5f26aff4d95efc8e9fed34f3b1e"
+                    "url" : "https://github.com/Wartybix/Constrict/archive/refs/tags/25.7.1.tar.gz",
+                    "sha256" : "3979958f07865c9a46a0a36625b304031ac6848c815b9e52a5b9f9b47ccf9cf2"
                 }
             ]
         }


### PR DESCRIPTION
Shorten the summary in the Metainfo and desktop file from 'Compress videos to target file sizes' to 'Compress videos to target sizes'.